### PR TITLE
setup tekton chains instance deployment on op1st

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,14 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - harshad16
-reviewers:
-  - HumairAK
+  - 4n4nd
   - goern
+  - harshad16
+  - HumairAK
+  - tumido
+reviewers:
+  - 4n4nd
+  - goern
+  - harshad16
+  - HumairAK
+  - tumido

--- a/tekton-chains/LICENSE
+++ b/tekton-chains/LICENSE
@@ -1,0 +1,13 @@
+ Copyright 2021 The Tekton Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.

--- a/tekton-chains/README.md
+++ b/tekton-chains/README.md
@@ -1,0 +1,4 @@
+# Tekton Chains
+
+This directory keeps the deployment manifest for the tekton chains instance for operate-first.<br>
+Current Tekton chains version: v0.5.0

--- a/tekton-chains/base/chains-config.yaml
+++ b/tekton-chains/base/chains-config.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chains-config
+  labels:
+    app.kubernetes.io/component: chains
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+    pipeline.tekton.dev/release: "devel"
+    version: "v0.5.0"

--- a/tekton-chains/base/config-logging.yaml
+++ b/tekton-chains/base/config-logging.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-logging
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+data:
+  # Common configuration for all knative codebase
+  zap-logger-config: |
+    {
+      "level": "info",
+      "development": false,
+      "sampling": {
+        "initial": 100,
+        "thereafter": 100
+      },
+      "outputPaths": ["stdout"],
+      "errorOutputPaths": ["stderr"],
+      "encoding": "json",
+      "encoderConfig": {
+        "timeKey": "ts",
+        "levelKey": "level",
+        "nameKey": "logger",
+        "callerKey": "caller",
+        "messageKey": "msg",
+        "stacktraceKey": "stacktrace",
+        "lineEnding": "",
+        "levelEncoder": "",
+        "timeEncoder": "iso8601",
+        "durationEncoder": "",
+        "callerEncoder": ""
+      }
+    }
+  # Log level overrides
+  loglevel.controller: "info"
+  loglevel.webhook: "info"

--- a/tekton-chains/base/kustomization.yaml
+++ b/tekton-chains/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- chains-config.yaml
+- config-logging.yaml
+- signing-secrets.yaml
+- tekton-chains-controller.yaml

--- a/tekton-chains/base/signing-secrets.yaml
+++ b/tekton-chains/base/signing-secrets.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: signing-secrets
+  labels:
+    app.kubernetes.io/component: chains
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+    pipeline.tekton.dev/release: "devel"
+    version: "v0.5.0"

--- a/tekton-chains/base/tekton-chains-controller.yaml
+++ b/tekton-chains/base/tekton-chains-controller.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-chains-controller
+  labels:
+    app.kubernetes.io/name: tekton-pipelines
+    app.kubernetes.io/component: chains
+    pipeline.tekton.dev/release: "devel"
+    version: "v0.5.0"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tekton-chains-controller
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+      labels:
+        app: tekton-chains-controller
+        app.kubernetes.io/name: tekton-pipelines
+        app.kubernetes.io/component: controller
+        # # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
+        # pipeline.tekton.dev/release: "devel"
+        version: "v0.5.0"
+    spec:
+      serviceAccountName: tekton-chains-controller
+      containers:
+        - name: tekton-chains-controller
+          image: gcr.io/tekton-releases/github.com/tektoncd/chains/cmd/controller:v0.5.0@sha256:3b9d98af5fcdb3c9e481d3cbf80d5d89ffc933883bc5e221bfae3a50f1535a63
+          volumeMounts:
+            - name: signing-secrets
+              mountPath: /etc/signing-secrets
+          env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: METRICS_DOMAIN
+              value: tekton.dev/chains
+      volumes:
+        - name: signing-secrets
+          secret:
+            secretName: signing-secrets

--- a/tekton-chains/overlays/moc/chains-controller-leaderelection-rbac.yaml
+++ b/tekton-chains/overlays/moc/chains-controller-leaderelection-rbac.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-chains-controller-leaderelection
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+subjects:
+  - kind: ServiceAccount
+    name: tekton-chains-controller
+    namespace: tekton-chains
+roleRef:
+  kind: Role
+  name: tekton-chains-leader-election
+  apiGroup: rbac.authorization.k8s.io

--- a/tekton-chains/overlays/moc/chains-controller-sa.yaml
+++ b/tekton-chains/overlays/moc/chains-controller-sa.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-chains-controller
+  labels:
+    app.kubernetes.io/component: chains
+    app.kubernetes.io/part-of: tekton-pipelines

--- a/tekton-chains/overlays/moc/chains-leader-election-roles.yaml
+++ b/tekton-chains/overlays/moc/chains-leader-election-roles.yaml
@@ -1,0 +1,22 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-chains-leader-election
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+rules:
+  # We uses leases for leaderelection
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - "leases"
+    verbs:
+      - "get"
+      - "list"
+      - "create"
+      - "update"
+      - "delete"
+      - "patch"
+      - "watch"

--- a/tekton-chains/overlays/moc/kustomization.yaml
+++ b/tekton-chains/overlays/moc/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+- chains-controller-leaderelection-rbac.yaml
+- chains-controller-sa.yaml
+- chains-leader-election-roles.yaml


### PR DESCRIPTION
feat: setup tekton chains instance deployment on op1st
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: 
- https://github.com/operate-first/support/issues/438
- https://github.com/operate-first/apps/pull/1278

## Description

- [x] Tekton chains provide security to our pipeline supply chains.
It would sign the images based on the secrets.
https://github.com/tektoncd/chains#installation

- [x] Updated the list of OWNERS.