### PR TITLE
Connaisseur

### DIFF
--- a/connaisseur/README.md
+++ b/connaisseur/README.md
@@ -1,0 +1,20 @@
+# Connaisseur
+Connaisseur allows for validating signed images. The verification only takes place on namespaces that have the following label.
+
+```
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    kubernetes.io/metadata.name: test
+    securesystemsengineering.connaisseur/webhook: validate
+```
+
+This can be tested by trying to deploy an image that has not been signed.
+```
+oc run pacman --image quay.io/rcook/pacman-nodejs-app
+Error from server: admission webhook "connaisseur-svc.connaisseur.svc" denied the request: Unexpected Cosign exception for image "quay.io/rcook/pacman-nodejs-app:latest": Error: unknown mime type: application/vnd.docker.distribution.manifest.v1+prettyjws
+```
+
+## Project
+The project is located at https://github.com/sse-secure-systems/connaisseur

--- a/connaisseur/base/connaisseur-namespace.yaml
+++ b/connaisseur/base/connaisseur-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: connaisseur

--- a/connaisseur/base/kustomization.yaml
+++ b/connaisseur/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- connaisseur-namespace.yaml

--- a/connaisseur/overlays/argocd/connaisseur-application.yaml
+++ b/connaisseur/overlays/argocd/connaisseur-application.yaml
@@ -1,0 +1,42 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: connaisseur
+spec:
+  destination:
+    namespace: connaisseur
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    chart: connaisseur
+    helm:
+      parameters:
+      - name: deployment.securityContext.runAsUser
+        value: "null"
+      - name: deployment.securityContext.runAsGroup
+        value: "null"
+      - name: namespacedValidation.mode
+        value: validate
+      - name: namespacedValidation.enabled
+        value: "true"
+      - name: deployment.securityContext.seccompProfile.type
+        value: "null"
+      - name: deployment.securityContext.seccompProfile
+        value: "null"
+      values: |-
+        validators:
+        - name: default
+          type: cosign
+          trust_roots:
+          - name: default
+            key: |
+              -----BEGIN PUBLIC KEY-----
+              MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEMecau+YfMFWYrNmwY3YHMwp8UM51
+              qefyvhYr2qebJXPmXG1WpbljWcg9g1FOhPiey9HsLImh1kWdclw/czCWQw==
+              -----END PUBLIC KEY-----
+    repoURL: https://sse-secure-systems.github.io/connaisseur/charts
+    targetRevision: 1.1.0
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/connaisseur/overlays/argocd/kustomization.yaml
+++ b/connaisseur/overlays/argocd/kustomization.yaml
@@ -3,5 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../../../base
+  - ../../base
   - connaisseur-application.yaml

--- a/connaisseur/overlays/argocd/kustomization.yaml
+++ b/connaisseur/overlays/argocd/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../base
+  - connaisseur-application.yaml


### PR DESCRIPTION
## Related Issues and Dependencies
https://github.com/AICoE/summit-2021-octo-keynote/issues/16#event-5906867178
…

## This introduces a breaking change

- [ ] Yes
- [X] No

## This Pull Request implements
This pull request will deploy the helm chart for Connaisseur and modify the default values as it relates to OpenShift and the public key of our signed images. 

NOTE: This can be installed on any cluster and until namespaces are labeled with the specific label images will not be blocked from being deployed.

## Description
ArgoCD application definition for the deployment of the helm chart. Kustomize is used in the event that RHACM application configuration may need to be applied.