### PR TITLE
:fire: Patch the chains config to fix the manifest type issue

### DIFF
--- a/tekton-chains/base/chains-config.yaml
+++ b/tekton-chains/base/chains-config.yaml
@@ -10,6 +10,7 @@ metadata:
     pipeline.tekton.dev/release: "devel"
     version: "v0.6.1"
 data:
-  artifacts.taskrun.format: in-toto
-  artifacts.taskrun.storage: oci
-  transparency.enabled: "true"
+  artifacts.oci.storage: oci
+  artifacts.taskrun.format: tekton
+  artifacts.taskrun.storage: tekton
+  transparency.enabled: 'true'


### PR DESCRIPTION
Patch the chains config to fix the manifest type issue
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/AICoE/summit-2021-octo-keynote/issues/7

## Description

This pr fixes the tekton chains issue in pushing images to quay.
`manifest data does not match schema`